### PR TITLE
Added default ctor and explicit init function

### DIFF
--- a/offsetAllocator.cpp
+++ b/offsetAllocator.cpp
@@ -134,17 +134,20 @@ namespace OffsetAllocator
     }
 
     // Allocator...
-    Allocator::Allocator(uint32 size, uint32 maxAllocs) :
-        m_size(size),
-        m_maxAllocs(maxAllocs),
+    Allocator::Allocator() :
+        m_size(0),
+        m_maxAllocs(0),
         m_nodes(nullptr),
         m_freeNodes(nullptr)
     {
-        if (sizeof(NodeIndex) == 2)
-        {
-            ASSERT(maxAllocs <= 65536);
-        }
         reset();
+    }
+
+    Allocator::Allocator(uint32 size, uint32 maxAllocs) :
+        m_nodes(nullptr),
+        m_freeNodes(nullptr)
+    {       
+        init(size, maxAllocs);
     }
 
     Allocator::Allocator(Allocator &&other) :
@@ -166,6 +169,19 @@ namespace OffsetAllocator
         other.m_usedBinsTop = 0;
     }
 
+    void Allocator::init(uint32 size, uint32 maxAllocs)
+    {
+		if (sizeof(NodeIndex) == 2)
+		{
+			ASSERT(maxAllocs <= 65536);
+		}
+
+		m_size = size;
+		m_maxAllocs = maxAllocs;
+        reset();       
+        initInternal();
+    }
+
     void Allocator::reset()
     {
         m_freeStorage = 0;
@@ -180,7 +196,10 @@ namespace OffsetAllocator
         
         if (m_nodes) delete[] m_nodes;
         if (m_freeNodes) delete[] m_freeNodes;
+    }
 
+    void Allocator::initInternal()
+    {
         m_nodes = new Node[m_maxAllocs];
         m_freeNodes = new NodeIndex[m_maxAllocs];
         

--- a/offsetAllocator.hpp
+++ b/offsetAllocator.hpp
@@ -51,9 +51,11 @@ namespace OffsetAllocator
     class Allocator
     {
     public:
+        Allocator();
         Allocator(uint32 size, uint32 maxAllocs = 128 * 1024);
         Allocator(Allocator &&other);
         ~Allocator();
+        void init(uint32 size, uint32 maxAllocs = 128 * 1024);
         void reset();
         
         Allocation allocate(uint32 size);
@@ -64,6 +66,7 @@ namespace OffsetAllocator
         StorageReportFull storageReportFull() const;
         
     private:
+        void initInternal();
         uint32 insertNodeIntoBin(uint32 size, uint32 dataOffset);
         void removeNodeFromBin(uint32 nodeIndex);
 


### PR DESCRIPTION
Minor change that decouples the initialization from the constructor.
Introducing a default constructor (leaves allocator in uninitialized state) and explicit initialization function.
This allows to have the allocator on the stack (for example as a member) and only to be allocated at the right time (because for example the size calculation is complex or depends on other initialization)


```
class foo {

public:

void Init() {
    size_t size = Calculate();
    allocator.init(size);
}

private:
OffsetAllocator::Allocatorallocator;

};
```